### PR TITLE
Add ability to pass App Secret Proof with API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2 (2017-07-20)
+ - Added ability to configure App Secret to be included with API requests
+
 ## 0.1.12 (2017-05-25)
  - Added complete set of ad campaign objectives. (#9, @cte)
  - Switched to rspec from minitest. (#8, @cte)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ You'll need an [Access Token](https://developers.facebook.com/docs/marketing-api
 FacebookAds.access_token = '[YOUR_ACCESS_TOKEN]'
 ```
 
+You can also optionally include an [App Secret](https://developers.facebook.com/docs/accountkit/graphapi#app-tokens) if you need one for your application.
+
+```ruby
+FacebookAds.app_secret = '[YOUR_APP_SECRET]'
+```
+
 ## API Version
 
 This gem currently uses v2.8 of the Marketing API (soon to be updated to 2.9). You can change the version as desired with the following:

--- a/facebook_ads.gemspec
+++ b/facebook_ads.gemspec
@@ -2,10 +2,10 @@
 
 # To publish the next version:
 # gem build facebook_ads.gemspec
-# gem push facebook_ads-0.1.12.gem
+# gem push facebook_ads-0.2.gem
 Gem::Specification.new do |s|
   s.name        = 'facebook_ads'
-  s.version     = '0.1.12'
+  s.version     = '0.2'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
   s.authors     = ['Chris Estreich']

--- a/lib/facebook_ads.rb
+++ b/lib/facebook_ads.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'rest-client'
 require 'hashie'
 require 'logger'
+require 'openssl'
 
 # Internal requires.
 require 'facebook_ads/base'
@@ -38,6 +39,22 @@ module FacebookAds
 
   def self.access_token
     @access_token
+  end
+
+  def self.app_secret=(app_secret)
+    @app_secret = app_secret
+  end
+
+  def self.app_secret
+    @app_secret
+  end
+
+  def self.appsecret_proof
+    OpenSSL::HMAC.hexdigest(
+      OpenSSL::Digest.new('sha256'),
+      @app_secret,
+      @access_token
+    )
   end
 
   def self.business_id=(business_id)

--- a/lib/facebook_ads/base.rb
+++ b/lib/facebook_ads/base.rb
@@ -84,6 +84,7 @@ module FacebookAds
 
       def pack(hash, objectify:)
         hash = hash.merge(access_token: FacebookAds.access_token)
+        hash = hash.merge(appsecret_proof: FacebookAds.appsecret_proof) if FacebookAds.app_secret
         hash = hash.merge(fields: self::FIELDS.join(',')) if objectify
         hash.delete_if { |_k, v| v.nil? }
       end

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_campaigns/lists_campaigns.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_campaigns/lists_campaigns.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.8/act_10152335766987003/campaigns?access_token=<access_token>&effective_status%5B%5D=ACTIVE&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap&limit=100
+    uri: https://graph.facebook.com/v2.8/act_10152335766987003/campaigns?access_token=<access_token>&appsecret_proof=<appsecret_proof>&effective_status%5B%5D=ACTIVE&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap&limit=100
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_creatives/lists_creatives.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_creatives/lists_creatives.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.8/act_10152335766987003/adcreatives?access_token=<access_token>&fields=id,name,object_story_id,object_story_spec,object_type,thumbnail_url,run_status&limit=100
+    uri: https://graph.facebook.com/v2.8/act_10152335766987003/adcreatives?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,name,object_story_id,object_story_spec,object_type,thumbnail_url,run_status&limit=100
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_images/lists_images.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_images/lists_images.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.8/act_10152335766987003/adimages?access_token=<access_token>&fields=id,hash,account_id,name,permalink_url,original_width,original_height&hashes%5B%5D=d8fc613662fb5ef6cf5fb9d1fe779315
+    uri: https://graph.facebook.com/v2.8/act_10152335766987003/adimages?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,hash,account_id,name,permalink_url,original_width,original_height&hashes%5B%5D=d8fc613662fb5ef6cf5fb9d1fe779315
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_sets/lists_ad_sets.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_sets/lists_ad_sets.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.8/act_10152335766987003/adsets?access_token=<access_token>&effective_status%5B%5D=ACTIVE&fields=id,account_id,campaign_id,name,status,configured_status,effective_status,bid_amount,billing_event,optimization_goal,pacing_type,daily_budget,budget_remaining,lifetime_budget,promoted_object,targeting,created_time,updated_time&limit=100
+    uri: https://graph.facebook.com/v2.8/act_10152335766987003/adsets?access_token=<access_token>&appsecret_proof=<appsecret_proof>&effective_status%5B%5D=ACTIVE&fields=id,account_id,campaign_id,name,status,configured_status,effective_status,bid_amount,billing_event,optimization_goal,pacing_type,daily_budget,budget_remaining,lifetime_budget,promoted_object,targeting,created_time,updated_time&limit=100
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_ads/lists_ads.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_ads/lists_ads.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.8/act_10152335766987003/ads?access_token=<access_token>&effective_status%5B%5D=ACTIVE&fields=id,account_id,campaign_id,adset_id,adlabels,bid_amount,bid_info,bid_type,configured_status,conversion_specs,created_time,creative,effective_status,last_updated_by_app_id,name,tracking_specs,updated_time,ad_review_feedback&limit=100
+    uri: https://graph.facebook.com/v2.8/act_10152335766987003/ads?access_token=<access_token>&appsecret_proof=<appsecret_proof>&effective_status%5B%5D=ACTIVE&fields=id,account_id,campaign_id,adset_id,adlabels,bid_amount,bid_info,bid_type,configured_status,conversion_specs,created_time,creative,effective_status,last_updated_by_app_id,name,tracking_specs,updated_time,ad_review_feedback&limit=100
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_all/lists_all_accounts.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_all/lists_all_accounts.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.8/me/adaccounts?access_token=<access_token>&fields=id,account_id,account_status,age,created_time,currency,name
+    uri: https://graph.facebook.com/v2.8/me/adaccounts?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,account_id,account_status,age,created_time,currency,name
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_create_ad_campaign/creates_a_new_ad_campaign.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_create_ad_campaign/creates_a_new_ad_campaign.yml
@@ -61,7 +61,7 @@ http_interactions:
   recorded_at: Wed, 26 Apr 2017 00:48:41 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.8/6076262393242?access_token=<access_token>&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap
+    uri: https://graph.facebook.com/v2.8/6076262393242?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_create_ad_images/creates_an_image.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_create_ad_images/creates_an_image.yml
@@ -2811,7 +2811,7 @@ http_interactions:
   recorded_at: Wed, 26 Apr 2017 00:48:43 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.8/act_10152335766987003/adimages?access_token=<access_token>&fields=id,hash,account_id,name,permalink_url,original_width,original_height&hashes%5B%5D=d8fc613662fb5ef6cf5fb9d1fe779315
+    uri: https://graph.facebook.com/v2.8/act_10152335766987003/adimages?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,hash,account_id,name,permalink_url,original_width,original_height&hashes%5B%5D=d8fc613662fb5ef6cf5fb9d1fe779315
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_find_by/finds_a_specific_account.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_find_by/finds_a_specific_account.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.8/me/adaccounts?access_token=<access_token>&fields=id,account_id,account_status,age,created_time,currency,name
+    uri: https://graph.facebook.com/v2.8/me/adaccounts?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,account_id,account_status,age,created_time,currency,name
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_reach_estimate/estimates_the_reach_of_a_targeting_spec.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_reach_estimate/estimates_the_reach_of_a_targeting_spec.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.8/act_10152335766987003/reachestimate?access_token=<access_token>&currency=USD&optimize_for=OFFSITE_CONVERSIONS&targeting_spec=%7B%22genders%22:%5B2%5D,%22age_min%22:18,%22age_max%22:20,%22geo_locations%22:%7B%22countries%22:%5B%22US%22%5D%7D%7D
+    uri: https://graph.facebook.com/v2.8/act_10152335766987003/reachestimate?access_token=<access_token>&appsecret_proof=<appsecret_proof>&currency=USD&optimize_for=OFFSITE_CONVERSIONS&targeting_spec=%7B%22genders%22:%5B2%5D,%22age_min%22:18,%22age_max%22:20,%22geo_locations%22:%7B%22countries%22:%5B%22US%22%5D%7D%7D
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/FacebookAds_AdCampaign/_destroy/creates_a_new_ad_campaign.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdCampaign/_destroy/creates_a_new_ad_campaign.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.8/6076262142242?access_token=<access_token>&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap
+    uri: https://graph.facebook.com/v2.8/6076262142242?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap
     body:
       encoding: US-ASCII
       string: ''
@@ -55,7 +55,7 @@ http_interactions:
   recorded_at: Wed, 26 Apr 2017 00:52:19 GMT
 - request:
     method: delete
-    uri: https://graph.facebook.com/v2.8/6076262142242?access_token=<access_token>
+    uri: https://graph.facebook.com/v2.8/6076262142242?access_token=<access_token>&appsecret_proof=<appsecret_proof>
     body:
       encoding: US-ASCII
       string: ''
@@ -110,7 +110,7 @@ http_interactions:
   recorded_at: Wed, 26 Apr 2017 00:52:20 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.8/6076262142242?access_token=<access_token>&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap
+    uri: https://graph.facebook.com/v2.8/6076262142242?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/support/facebook_ads.rb
+++ b/spec/support/facebook_ads.rb
@@ -1,4 +1,5 @@
 FacebookAds.business_id  = '760977220612233'
 FacebookAds.access_token = ENV['FACEBOOK_ACCESS_TOKEN'] || 'fake-facebook-access-token'
+FacebookAds.app_secret   = ENV['FACEBOOK_APP_SECRET']   || 'fake-facebook-app-secret'
 # FacebookAds.logger       = Logger.new(STDOUT)
 # FacebookAds.logger.level = Logger::Severity::DEBUG

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -7,10 +7,13 @@ VCR.configure do |c|
   c.default_cassette_options = {
     match_requests_on: [
       :method,
-      VCR.request_matchers.uri_without_param(:access_token)
+      VCR.request_matchers.uri_without_param(:access_token, :app_secret)
     ]
   }
   c.filter_sensitive_data('<access_token>') do
-    ENV['FACEBOOK_ACCESS_TOKEN']
+    FacebookAds.access_token
+  end
+  c.filter_sensitive_data('<appsecret_proof>') do
+    FacebookAds.appsecret_proof
   end
 end


### PR DESCRIPTION
In v2.10 of the Facebook Graph API, the following restriction was added:

> App Restriction Enforcement - Specifying an access token for a user who fails the application's restrictions (such as country or age) will result in an error, unless an appsecret_proof is specified in the request.

This commit adds support for an optional app secret configuration variable that will then be hashed appropriately and included with API requests.