### PR TITLE
Add manual bid support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.3 (2017-07-20)
+## 0.4 (2017-07-25)
+ - Added ability to pass `bid_amount` parameter when creating ad sets
+ - Ad Set `is_autobid` parameter now defaults to `nil` rather than `true`
+
+## 0.3 (2017-07-24)
  - Added ability to pass `app_link` parameter with ad creatives
 
 ## 0.2 (2017-07-20)

--- a/facebook_ads.gemspec
+++ b/facebook_ads.gemspec
@@ -2,10 +2,10 @@
 
 # To publish the next version:
 # gem build facebook_ads.gemspec
-# gem push facebook_ads-0.3.gem
+# gem push facebook_ads-0.4.gem
 Gem::Specification.new do |s|
   s.name        = 'facebook_ads'
-  s.version     = '0.3'
+  s.version     = '0.4'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
   s.authors     = ['Chris Estreich']

--- a/lib/facebook_ads/ad_campaign.rb
+++ b/lib/facebook_ads/ad_campaign.rb
@@ -60,7 +60,7 @@ module FacebookAds
       AdSet.paginate("/#{id}/adsets", query: { effective_status: effective_status, limit: limit })
     end
 
-    def create_ad_set(name:, promoted_object:, targeting:, daily_budget:, optimization_goal:, billing_event: 'IMPRESSIONS', status: 'ACTIVE', is_autobid: nil)
+    def create_ad_set(name:, promoted_object:, targeting:, daily_budget:, optimization_goal:, billing_event: 'IMPRESSIONS', status: 'ACTIVE', is_autobid: nil, bid_amount: nil)
       raise Exception, "Optimization goal must be one of: #{AdSet::OPTIMIZATION_GOALS.join(', ')}" unless AdSet::OPTIMIZATION_GOALS.include?(optimization_goal)
       raise Exception, "Billing event must be one of: #{AdSet::BILLING_EVENTS.join(', ')}" unless AdSet::BILLING_EVENTS.include?(billing_event)
 
@@ -80,7 +80,8 @@ module FacebookAds
         daily_budget: daily_budget,
         billing_event: billing_event,
         status: status,
-        is_autobid: is_autobid
+        is_autobid: is_autobid,
+        bid_amount: bid_amount
       }
       result = AdSet.post("/act_#{account_id}/adsets", query: query)
       AdSet.find(result['id'])

--- a/lib/facebook_ads/ad_campaign.rb
+++ b/lib/facebook_ads/ad_campaign.rb
@@ -60,7 +60,7 @@ module FacebookAds
       AdSet.paginate("/#{id}/adsets", query: { effective_status: effective_status, limit: limit })
     end
 
-    def create_ad_set(name:, promoted_object:, targeting:, daily_budget:, optimization_goal:, billing_event: 'IMPRESSIONS', status: 'ACTIVE', is_autobid: true)
+    def create_ad_set(name:, promoted_object:, targeting:, daily_budget:, optimization_goal:, billing_event: 'IMPRESSIONS', status: 'ACTIVE', is_autobid: nil)
       raise Exception, "Optimization goal must be one of: #{AdSet::OPTIMIZATION_GOALS.join(', ')}" unless AdSet::OPTIMIZATION_GOALS.include?(optimization_goal)
       raise Exception, "Billing event must be one of: #{AdSet::BILLING_EVENTS.join(', ')}" unless AdSet::BILLING_EVENTS.include?(billing_event)
 

--- a/lib/facebook_ads/ad_set.rb
+++ b/lib/facebook_ads/ad_set.rb
@@ -24,7 +24,7 @@ module FacebookAds
       id account_id campaign_id
       name
       status configured_status effective_status
-      bid_amount billing_event optimization_goal pacing_type
+      is_autobid bid_amount billing_event optimization_goal pacing_type
       daily_budget budget_remaining lifetime_budget
       promoted_object
       targeting

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_sets/lists_ad_sets.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_sets/lists_ad_sets.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/v2.8/act_10152335766987003/adsets?access_token=<access_token>&appsecret_proof=<appsecret_proof>&effective_status%5B%5D=ACTIVE&fields=id,account_id,campaign_id,name,status,configured_status,effective_status,bid_amount,billing_event,optimization_goal,pacing_type,daily_budget,budget_remaining,lifetime_budget,promoted_object,targeting,created_time,updated_time&limit=100
+    uri: https://graph.facebook.com/v2.8/act_10152335766987003/adsets?access_token=<access_token>&appsecret_proof=<appsecret_proof>&effective_status%5B%5D=ACTIVE&fields=id,account_id,campaign_id,name,status,configured_status,effective_status,is_autobid,bid_amount,billing_event,optimization_goal,pacing_type,daily_budget,budget_remaining,lifetime_budget,promoted_object,targeting,created_time,updated_time&limit=100
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
⚠️ This does include a breaking API change. ⚠️

Generally adds ability to pass `bid_amount` parameter when creating ad sets.

But also changes ad set `is_autobid` parameter default to `nil` (was `true`). This is a breaking change for current users of this library, but I think it's essential for moving forward. Rationale:

- The previous behavior (defaulting to true) is not aligned with how
  the official FB SDK works, which is not opinionated about default
  parameter values. We shouldn't be opinionated this way either.

- In the future we want to support the `bid_amount` parameter. However
  with `is_autobid` defaulting to true, if someone were to pass
  `bid_amount` without explicitly turning off autobid, the request
  would fail. That seems like an obvious developer trap that we can
  avoid by making users be explicit about autobid when they want it.

Normally a breaking change like this would require a major version
number increment, but since we're on major version 0 the public API is
not expected to be stable, so I plan to just bump the minor version
number.