### PR TITLE
Add back ad creative status field

### DIFF
--- a/facebook_ads.gemspec
+++ b/facebook_ads.gemspec
@@ -2,10 +2,10 @@
 
 # To publish the next version:
 # gem build facebook_ads.gemspec
-# gem push facebook_ads-0.4.gem
+# gem push facebook_ads-0.5.1.gem
 Gem::Specification.new do |s|
   s.name        = 'facebook_ads'
-  s.version     = '0.5'
+  s.version     = '0.5.1'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
   s.authors     = ['Chris Estreich']

--- a/lib/facebook_ads/ad_creative.rb
+++ b/lib/facebook_ads/ad_creative.rb
@@ -2,7 +2,7 @@ module FacebookAds
   # Ad ad creative has many ad images and belongs to an ad account.
   # https://developers.facebook.com/docs/marketing-api/reference/ad-creative
   class AdCreative < Base
-    FIELDS               = %w[id name object_story_id object_story_spec object_type thumbnail_url].freeze
+    FIELDS               = %w[id name object_story_id object_story_spec object_type thumbnail_url status].freeze
     CALL_TO_ACTION_TYPES = %w[SHOP_NOW INSTALL_MOBILE_APP USE_MOBILE_APP SIGN_UP DOWNLOAD BUY_NOW NO_BUTTON].freeze
 
     class << self

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_creatives/lists_creatives.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_creatives/lists_creatives.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/v<api_version>/act_10152335766987003/adcreatives?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,name,object_story_id,object_story_spec,object_type,thumbnail_url&limit=100
+    uri: https://graph.facebook.com/v<api_version>/act_10152335766987003/adcreatives?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,name,object_story_id,object_story_spec,object_type,thumbnail_url,status&limit=100
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_create_ad_creative/creates_carousel_ad_creative.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_create_ad_creative/creates_carousel_ad_creative.yml
@@ -7244,7 +7244,7 @@ http_interactions:
   recorded_at: Fri, 25 Aug 2017 22:08:06 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/v<api_version>/120330000008134415?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,name,object_story_id,object_story_spec,object_type,thumbnail_url
+    uri: https://graph.facebook.com/v<api_version>/120330000008134415?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,name,object_story_id,object_story_spec,object_type,thumbnail_url,status
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
This was formerly known as `run_status` and deprecated after v2.8, but it seems to be replaced by `status` in v2.9 and later.

