### PR TITLE
Update campaign objectives

### DIFF
--- a/facebook_ads.gemspec
+++ b/facebook_ads.gemspec
@@ -2,10 +2,10 @@
 
 # To publish the next version:
 # gem build facebook_ads.gemspec
-# gem push facebook_ads-0.5.1.gem
+# gem push facebook_ads-0.6.0.gem
 Gem::Specification.new do |s|
   s.name        = 'facebook_ads'
-  s.version     = '0.5.1'
+  s.version     = '0.6.0'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
   s.authors     = ['Chris Estreich']

--- a/lib/facebook_ads/ad_campaign.rb
+++ b/lib/facebook_ads/ad_campaign.rb
@@ -30,22 +30,19 @@ module FacebookAds
     ].freeze
 
     OBJECTIVES = %w[
+      APP_INSTALLS
       BRAND_AWARENESS
-      CANVAS_APP_ENGAGEMENT
-      CANVAS_APP_INSTALLS
+      CONVERSIONS
       EVENT_RESPONSES
       LEAD_GENERATION
+      LINK_CLICKS
       LOCAL_AWARENESS
-      MOBILE_APP_ENGAGEMENT
-      MOBILE_APP_INSTALLS
-      NONE
       OFFER_CLAIMS
       PAGE_LIKES
       POST_ENGAGEMENT
-      LINK_CLICKS
-      CONVERSIONS
-      VIDEO_VIEWS
       PRODUCT_CATALOG_SALES
+      REACH
+      VIDEO_VIEWS
     ].freeze
 
     # belongs_to ad_account

--- a/lib/facebook_ads/ad_set.rb
+++ b/lib/facebook_ads/ad_set.rb
@@ -37,6 +37,7 @@ module FacebookAds
       NONE
       APP_INSTALLS
       BRAND_AWARENESS
+      AD_RECALL_LIFT
       CLICKS
       ENGAGED_USERS
       EVENT_RESPONSES
@@ -52,6 +53,7 @@ module FacebookAds
       SOCIAL_IMPRESSIONS
       VIDEO_VIEWS
       APP_DOWNLOADS
+      LANDING_PAGE_VIEWS
     ].freeze
 
     # belongs_to ad_account

--- a/spec/facebook_ads/ad_account_spec.rb
+++ b/spec/facebook_ads/ad_account_spec.rb
@@ -37,7 +37,7 @@ describe FacebookAds::AdAccount do
 
   describe '.create_ad_campaign' do
     it 'creates a new ad campaign', :vcr do
-      ad_campaign = account.create_ad_campaign(name: 'Test', objective: 'MOBILE_APP_INSTALLS')
+      ad_campaign = account.create_ad_campaign(name: 'Test', objective: 'APP_INSTALLS')
       verify(format: :json) { JSON.dump(ad_campaign) }
     end
   end

--- a/spec/fixtures/approvals/facebookads_adaccount/ad_campaigns/lists_campaigns.approved.json
+++ b/spec/fixtures/approvals/facebookads_adaccount/ad_campaigns/lists_campaigns.approved.json
@@ -8,7 +8,7 @@
     "created_time": "<time>",
     "effective_status": "ACTIVE",
     "name": "Test",
-    "objective": "MOBILE_APP_INSTALLS",
+    "objective": "APP_INSTALLS",
     "start_time": "<time>",
     "updated_time": "<time>"
   }

--- a/spec/fixtures/approvals/facebookads_adaccount/create_ad_campaign/creates_a_new_ad_campaign.approved.json
+++ b/spec/fixtures/approvals/facebookads_adaccount/create_ad_campaign/creates_a_new_ad_campaign.approved.json
@@ -7,7 +7,7 @@
   "created_time": "<time>",
   "effective_status": "ACTIVE",
   "name": "Test",
-  "objective": "MOBILE_APP_INSTALLS",
+  "objective": "APP_INSTALLS",
   "start_time": "<time>",
   "updated_time": "<time>"
 }

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_campaigns/lists_campaigns.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_campaigns/lists_campaigns.yml
@@ -50,7 +50,7 @@ http_interactions:
       - '434'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"6076261167842","account_id":"10152335766987003","buying_type":"AUCTION","can_use_spend_cap":true,"configured_status":"ACTIVE","created_time":"2017-04-25T16:54:27-0700","effective_status":"ACTIVE","name":"Test","objective":"MOBILE_APP_INSTALLS","start_time":"1969-12-31T15:59:59-0800","updated_time":"2017-04-25T16:54:27-0700"}],"paging":{"cursors":{"before":"NjA3NjI2MTE2Nzg0MgZDZD","after":"NjA3NjI2MTE2Nzg0MgZDZD"}}}'
+      string: '{"data":[{"id":"6076261167842","account_id":"10152335766987003","buying_type":"AUCTION","can_use_spend_cap":true,"configured_status":"ACTIVE","created_time":"2017-04-25T16:54:27-0700","effective_status":"ACTIVE","name":"Test","objective":"APP_INSTALLS","start_time":"1969-12-31T15:59:59-0800","updated_time":"2017-04-25T16:54:27-0700"}],"paging":{"cursors":{"before":"NjA3NjI2MTE2Nzg0MgZDZD","after":"NjA3NjI2MTE2Nzg0MgZDZD"}}}'
     http_version:
   recorded_at: Wed, 26 Apr 2017 00:48:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_create_ad_campaign/creates_a_new_ad_campaign.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_create_ad_campaign/creates_a_new_ad_campaign.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://graph.facebook.com/v<api_version>/act_10152335766987003/campaigns
     body:
       encoding: UTF-8
-      string: name=Test&objective=MOBILE_APP_INSTALLS&status=ACTIVE&access_token=<access_token>
+      string: name=Test&objective=APP_INSTALLS&status=ACTIVE&access_token=<access_token>
     headers:
       Accept:
       - application/json
@@ -109,7 +109,7 @@ http_interactions:
       - '333'
     body:
       encoding: UTF-8
-      string: '{"id":"6076262393242","account_id":"10152335766987003","buying_type":"AUCTION","can_use_spend_cap":true,"configured_status":"ACTIVE","created_time":"2017-04-25T17:48:41-0700","effective_status":"ACTIVE","name":"Test","objective":"MOBILE_APP_INSTALLS","start_time":"1969-12-31T15:59:59-0800","updated_time":"2017-04-25T17:48:41-0700"}'
+      string: '{"id":"6076262393242","account_id":"10152335766987003","buying_type":"AUCTION","can_use_spend_cap":true,"configured_status":"ACTIVE","created_time":"2017-04-25T17:48:41-0700","effective_status":"ACTIVE","name":"Test","objective":"APP_INSTALLS","start_time":"1969-12-31T15:59:59-0800","updated_time":"2017-04-25T17:48:41-0700"}'
     http_version:
   recorded_at: Wed, 26 Apr 2017 00:48:42 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/FacebookAds_AdCampaign/_destroy/sets_effective_status_to_deleted.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdCampaign/_destroy/sets_effective_status_to_deleted.yml
@@ -50,7 +50,7 @@ http_interactions:
       - '335'
     body:
       encoding: UTF-8
-      string: '{"id":"6076262142242","account_id":"10152335766987003","buying_type":"AUCTION","can_use_spend_cap":true,"configured_status":"DELETED","created_time":"2017-04-25T17:34:09-0700","effective_status":"DELETED","name":"Test","objective":"MOBILE_APP_INSTALLS","start_time":"1969-12-31T15:59:59-0800","updated_time":"2017-04-25T17:35:27-0700"}'
+      string: '{"id":"6076262142242","account_id":"10152335766987003","buying_type":"AUCTION","can_use_spend_cap":true,"configured_status":"DELETED","created_time":"2017-04-25T17:34:09-0700","effective_status":"DELETED","name":"Test","objective":"APP_INSTALLS","start_time":"1969-12-31T15:59:59-0800","updated_time":"2017-04-25T17:35:27-0700"}'
     http_version:
   recorded_at: Wed, 26 Apr 2017 00:52:19 GMT
 - request:
@@ -158,7 +158,7 @@ http_interactions:
       - '335'
     body:
       encoding: UTF-8
-      string: '{"id":"6076262142242","account_id":"10152335766987003","buying_type":"AUCTION","can_use_spend_cap":true,"configured_status":"DELETED","created_time":"2017-04-25T17:34:09-0700","effective_status":"DELETED","name":"Test","objective":"MOBILE_APP_INSTALLS","start_time":"1969-12-31T15:59:59-0800","updated_time":"2017-04-25T17:35:27-0700"}'
+      string: '{"id":"6076262142242","account_id":"10152335766987003","buying_type":"AUCTION","can_use_spend_cap":true,"configured_status":"DELETED","created_time":"2017-04-25T17:34:09-0700","effective_status":"DELETED","name":"Test","objective":"APP_INSTALLS","start_time":"1969-12-31T15:59:59-0800","updated_time":"2017-04-25T17:35:27-0700"}'
     http_version:
   recorded_at: Wed, 26 Apr 2017 00:52:20 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Update objectives with current list from FP API v2.9

Specifically, MOBILE_APP_INSTALLS is now APP_INSTALLS as of v2.9, which is the impetus for this change.

This list is the same for API v2.10 as v2.9 so this should be a forward-compatible change.