### PR TITLE
Update product catalogs path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.2 (2018-05-08)
+  - Set Product Catalog path to `/owned_product_catalogs` for API v2.11 compatibility
+
 ## 0.4 (2017-07-25)
  - Added ability to pass `bid_amount` parameter when creating ad sets
  - Ad Set `is_autobid` parameter now defaults to `nil` rather than `true`

--- a/facebook_ads.gemspec
+++ b/facebook_ads.gemspec
@@ -2,10 +2,10 @@
 
 # To publish the next version:
 # gem build facebook_ads.gemspec
-# gem push facebook_ads-0.6.0.gem
+# gem push facebook_ads-0.6.2.gem
 Gem::Specification.new do |s|
   s.name        = 'facebook_ads'
-  s.version     = '0.6.1'
+  s.version     = '0.6.2'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
   s.authors     = ['Chris Estreich']

--- a/lib/facebook_ads/ad_product_catalog.rb
+++ b/lib/facebook_ads/ad_product_catalog.rb
@@ -5,7 +5,7 @@ module FacebookAds
 
     class << self
       def all(query = {})
-        get("/#{FacebookAds.business_id}/product_catalogs", query: query, objectify: true)
+        get("/#{FacebookAds.business_id}/owned_product_catalogs", query: query, objectify: true)
       end
 
       def find_by(conditions)
@@ -18,7 +18,7 @@ module FacebookAds
 
       def create(name:)
         query = { name: name }
-        result = post("/#{FacebookAds.business_id}/product_catalogs", query: query)
+        result = post("/#{FacebookAds.business_id}/owned_product_catalogs", query: query)
         find(result['id'])
       end
     end


### PR DESCRIPTION
`/product_catalogs` doesn’t work on version `2.11` and above.
`/owned_product_catalogs` works on all versions.

https://developers.facebook.com/docs/marketing-api/reference/product-catalog/v2.11