### PR TITLE
Replaced deprecated `is_autobid` with new `bid_strategy` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.3 (2018-05-17)
+  - Replaced deprecated `is_autobid` with new `bid_strategy` field
+
 ## 0.6.2 (2018-05-08)
   - Set Product Catalog path to `/owned_product_catalogs` for API v2.11 compatibility
 

--- a/README.md
+++ b/README.md
@@ -313,11 +313,12 @@ ad_set = campaign.create_ad_set(
   daily_budget: 500, # This is in cents, so the daily budget here is $5.
   billing_event: 'IMPRESSIONS',
   status: 'PAUSED',
-  is_autobid: true
+  bid_strategy: 'LOWEST_COST_WITHOUT_CAP'
 )
 ```
 See FacebookAds::AdSet::OPTIMIZATION_GOALS for a list of all optimization goals.
 See FacebookAds::AdSet::BILLING_EVENTS for a list of all billing events.
+See FacebookAds::AdSet::BID_STRATEGIES for a list of all bid strategies.
 
 Find an ad set by ID:
 ```ruby

--- a/facebook_ads.gemspec
+++ b/facebook_ads.gemspec
@@ -5,7 +5,7 @@
 # gem push facebook_ads-0.6.2.gem
 Gem::Specification.new do |s|
   s.name        = 'facebook_ads'
-  s.version     = '0.6.2'
+  s.version     = '0.6.3'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
   s.authors     = ['Chris Estreich']

--- a/lib/facebook_ads/ad_campaign.rb
+++ b/lib/facebook_ads/ad_campaign.rb
@@ -57,9 +57,10 @@ module FacebookAds
       AdSet.paginate("/#{id}/adsets", query: { effective_status: effective_status, limit: limit })
     end
 
-    def create_ad_set(name:, promoted_object: {}, targeting:, daily_budget: nil, lifetime_budget: nil, end_time: nil, optimization_goal:, billing_event: 'IMPRESSIONS', status: 'ACTIVE', is_autobid: nil, bid_amount: nil)
+    def create_ad_set(name:, promoted_object: {}, targeting:, daily_budget: nil, lifetime_budget: nil, end_time: nil, optimization_goal:, billing_event: 'IMPRESSIONS', status: 'ACTIVE', bid_strategy: nil, bid_amount: nil)
       raise Exception, "Optimization goal must be one of: #{AdSet::OPTIMIZATION_GOALS.join(', ')}" unless AdSet::OPTIMIZATION_GOALS.include?(optimization_goal)
       raise Exception, "Billing event must be one of: #{AdSet::BILLING_EVENTS.join(', ')}" unless AdSet::BILLING_EVENTS.include?(billing_event)
+      raise Exception, "Bid strategy must be one of: #{AdSet::BID_STRATEGIES.join(', ')}" unless AdSet::BID_STRATEGIES.include?(bid_strategy)
 
       if targeting.is_a?(Hash)
         # NOP
@@ -76,7 +77,7 @@ module FacebookAds
         optimization_goal: optimization_goal,
         billing_event: billing_event,
         status: status,
-        is_autobid: is_autobid,
+        bid_strategy: bid_strategy,
         bid_amount: bid_amount
       }
 

--- a/lib/facebook_ads/ad_set.rb
+++ b/lib/facebook_ads/ad_set.rb
@@ -10,7 +10,7 @@ module FacebookAds
     #   creative_sequence daily_budget effective_status end_time
     #   frequency_cap frequency_cap_reset_period
     #   frequency_control_specs instagram_actor_id
-    #   is_autobid is_average_price_pacing lifetime_budget
+    #   bid_strategy lifetime_budget
     #   lifetime_frequency_cap lifetime_imps name optimization_goal
     #   pacing_type promoted_object recommendations
     #   recurring_budget_semantics rf_prediction_id rtb_flag
@@ -24,7 +24,7 @@ module FacebookAds
       id account_id campaign_id
       name
       status configured_status effective_status
-      is_autobid bid_amount billing_event optimization_goal pacing_type
+      bid_strategy bid_amount billing_event optimization_goal pacing_type
       daily_budget budget_remaining lifetime_budget
       promoted_object
       targeting
@@ -54,6 +54,11 @@ module FacebookAds
       VIDEO_VIEWS
       APP_DOWNLOADS
       LANDING_PAGE_VIEWS
+    ].freeze
+    BID_STRATEGIES = %w[
+      LOWEST_COST_WITHOUT_CAP
+      LOWEST_COST_WITH_BID_CAP
+      TARGET_COST
     ].freeze
 
     # belongs_to ad_account

--- a/spec/facebook_ads/ad_campaign_spec.rb
+++ b/spec/facebook_ads/ad_campaign_spec.rb
@@ -42,7 +42,7 @@ describe FacebookAds::AdCampaign do
         daily_budget: 500, # This is in cents, so the daily budget here is $5.
         billing_event: 'IMPRESSIONS',
         status: 'PAUSED',
-        is_autobid: true
+        bid_strategy: 'LOWEST_COST_WITHOUT_CAP'
       )
       expect(ad_set.id).to eq('120330000008135715')
     end

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_sets/lists_ad_sets.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_sets/lists_ad_sets.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/v<api_version>/act_10152335766987003/adsets?access_token=<access_token>&appsecret_proof=<appsecret_proof>&effective_status%5B%5D=ACTIVE&fields=id,account_id,campaign_id,name,status,configured_status,effective_status,is_autobid,bid_amount,billing_event,optimization_goal,pacing_type,daily_budget,budget_remaining,lifetime_budget,promoted_object,targeting,created_time,updated_time&limit=100
+    uri: https://graph.facebook.com/v<api_version>/act_10152335766987003/adsets?access_token=<access_token>&appsecret_proof=<appsecret_proof>&effective_status%5B%5D=ACTIVE&fields=id,account_id,campaign_id,name,status,configured_status,effective_status,bid_strategy,bid_amount,billing_event,optimization_goal,pacing_type,daily_budget,budget_remaining,lifetime_budget,promoted_object,targeting,created_time,updated_time&limit=100
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/FacebookAds_AdCampaign/_create_ad_set/creates_valid_ad_set.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdCampaign/_create_ad_set/creates_valid_ad_set.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://graph.facebook.com/v<api_version>/act_10152335766987003/adsets
     body:
       encoding: UTF-8
-      string: campaign_id=120330000008134915&name=Test+Ad+Set&targeting=%7B%22genders%22%3A%5B2%5D%2C%22age_min%22%3A29%2C%22age_max%22%3A65%2C%22geo_locations%22%3A%7B%22countries%22%3A%5B%22US%22%5D%7D%2C%22user_os%22%3A%5B%22Android%22%5D%2C%22user_device%22%3A%5B%22Android_Smartphone%22%2C%22Android_Tablet%22%5D%2C%22app_install_state%22%3A%22not_installed%22%2C%22income%22%3A%5B%5D%7D&promoted_object=%7B%7D&optimization_goal=IMPRESSIONS&billing_event=IMPRESSIONS&status=PAUSED&is_autobid=true&daily_budget=500&access_token=<access_token>&appsecret_proof=<appsecret_proof>
+      string: campaign_id=120330000008134915&name=Test+Ad+Set&targeting=%7B%22genders%22%3A%5B2%5D%2C%22age_min%22%3A29%2C%22age_max%22%3A65%2C%22geo_locations%22%3A%7B%22countries%22%3A%5B%22US%22%5D%7D%2C%22user_os%22%3A%5B%22Android%22%5D%2C%22user_device%22%3A%5B%22Android_Smartphone%22%2C%22Android_Tablet%22%5D%2C%22app_install_state%22%3A%22not_installed%22%2C%22income%22%3A%5B%5D%7D&promoted_object=%7B%7D&optimization_goal=IMPRESSIONS&billing_event=IMPRESSIONS&status=PAUSED&bid_strategy=LOWEST_COST_WITHOUT_CAP&daily_budget=500&access_token=<access_token>&appsecret_proof=<appsecret_proof>
     headers:
       Accept:
       - application/json
@@ -59,7 +59,7 @@ http_interactions:
   recorded_at: Sat, 26 Aug 2017 00:11:50 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/v<api_version>/120330000008135715?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,account_id,campaign_id,name,status,configured_status,effective_status,is_autobid,bid_amount,billing_event,optimization_goal,pacing_type,daily_budget,budget_remaining,lifetime_budget,promoted_object,targeting,created_time,updated_time
+    uri: https://graph.facebook.com/v<api_version>/120330000008135715?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,account_id,campaign_id,name,status,configured_status,effective_status,bid_strategy,bid_amount,billing_event,optimization_goal,pacing_type,daily_budget,budget_remaining,lifetime_budget,promoted_object,targeting,created_time,updated_time
     body:
       encoding: US-ASCII
       string: ''
@@ -108,7 +108,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"id":"120330000008135715","account_id":"10152335766987003","campaign_id":"120330000008134915","name":"Test
-        Ad Set","status":"PAUSED","configured_status":"PAUSED","effective_status":"PAUSED","is_autobid":true,"billing_event":"IMPRESSIONS","optimization_goal":"IMPRESSIONS","pacing_type":["standard"],"daily_budget":"500","budget_remaining":"0","lifetime_budget":"0","targeting":{"age_max":65,"age_min":29,"app_install_state":"not_installed","genders":[2],"geo_locations":{"countries":["US"],"location_types":["home"]},"user_device":["Android_Smartphone","Android_Tablet"],"user_os":["Android"]},"created_time":"2017-08-25T17:11:47-0700","updated_time":"2017-08-25T17:11:47-0700"}'
+        Ad Set","status":"PAUSED","configured_status":"PAUSED","effective_status":"PAUSED","bid_strategy":"LOWEST_COST_WITHOUT_CAP","billing_event":"IMPRESSIONS","optimization_goal":"IMPRESSIONS","pacing_type":["standard"],"daily_budget":"500","budget_remaining":"0","lifetime_budget":"0","targeting":{"age_max":65,"age_min":29,"app_install_state":"not_installed","genders":[2],"geo_locations":{"countries":["US"],"location_types":["home"]},"user_device":["Android_Smartphone","Android_Tablet"],"user_os":["Android"]},"created_time":"2017-08-25T17:11:47-0700","updated_time":"2017-08-25T17:11:47-0700"}'
     http_version: 
   recorded_at: Sat, 26 Aug 2017 00:11:50 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
This change is for v3.0 of the API. It replaces the deprecated `is_autobid` field with the new `bid_strategy` field. Here is a list of breaking changes in 3.0:

https://developers.facebook.com/docs/graph-api/changelog/version3.0#mapi-break

All 2.* versions will be deprecated on Aug 7, 2018. Here is the changelog where it shows the deprecation dates.
https://developers.facebook.com/docs/graph-api/changelog

Not sure if you want to wait to merge this pull request until then but I thought it would be a good idea to send this pull request right away so you know that the work has already been done.