### PR TITLE
Expose budget related fields for AdCampaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.4 (2018-10-03)
+  - Expose `budget_remaining`, `daily_budget`, `lifetime_budget` for Ad Campaigns. These are needed when we have budgets at the Ad Campaign level and not at the Ad Set level.
+
 ## 0.6.3 (2018-05-17)
   - Replaced deprecated `is_autobid` with new `bid_strategy` field
 

--- a/facebook_ads.gemspec
+++ b/facebook_ads.gemspec
@@ -3,10 +3,10 @@
 
 # To publish the next version:
 # gem build facebook_ads.gemspec
-# gem push facebook_ads-0.6.2.gem
+# gem push facebook_ads-0.6.4.gem
 Gem::Specification.new do |s|
   s.name        = 'facebook_ads'
-  s.version     = '0.6.3'
+  s.version     = '0.6.4'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
   s.authors     = ['Chris Estreich']

--- a/lib/facebook_ads/ad_campaign.rb
+++ b/lib/facebook_ads/ad_campaign.rb
@@ -16,6 +16,7 @@ module FacebookAds
       start_time
       stop_time
       updated_time spend_cap
+      budget_remaining daily_budget lifetime_budget
     ].freeze
 
     STATUSES = %w[

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_campaigns/lists_campaigns.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_ad_campaigns/lists_campaigns.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/v<api_version>/act_10152335766987003/campaigns?access_token=<access_token>&appsecret_proof=<appsecret_proof>&effective_status%5B%5D=ACTIVE&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap&limit=100
+    uri: https://graph.facebook.com/v<api_version>/act_10152335766987003/campaigns?access_token=<access_token>&appsecret_proof=<appsecret_proof>&effective_status%5B%5D=ACTIVE&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap,budget_remaining,daily_budget,lifetime_budget&limit=100
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/FacebookAds_AdAccount/_create_ad_campaign/creates_a_new_ad_campaign.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdAccount/_create_ad_campaign/creates_a_new_ad_campaign.yml
@@ -61,7 +61,7 @@ http_interactions:
   recorded_at: Wed, 26 Apr 2017 00:48:41 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/v<api_version>/6076262393242?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap
+    uri: https://graph.facebook.com/v<api_version>/6076262393242?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap,budget_remaining,daily_budget,lifetime_budget
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/FacebookAds_AdCampaign/_destroy/sets_effective_status_to_deleted.yml
+++ b/spec/fixtures/cassettes/FacebookAds_AdCampaign/_destroy/sets_effective_status_to_deleted.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://graph.facebook.com/v<api_version>/6076262142242?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap
+    uri: https://graph.facebook.com/v<api_version>/6076262142242?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap,budget_remaining,daily_budget,lifetime_budget
     body:
       encoding: US-ASCII
       string: ''
@@ -110,7 +110,7 @@ http_interactions:
   recorded_at: Wed, 26 Apr 2017 00:52:20 GMT
 - request:
     method: get
-    uri: https://graph.facebook.com/v<api_version>/6076262142242?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap
+    uri: https://graph.facebook.com/v<api_version>/6076262142242?access_token=<access_token>&appsecret_proof=<appsecret_proof>&fields=id,account_id,buying_type,can_use_spend_cap,configured_status,created_time,effective_status,name,objective,start_time,stop_time,updated_time,spend_cap,budget_remaining,daily_budget,lifetime_budget
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
- [x] Expose budget fields for AdCampaign. This is needed if we maintain budget at the ad_campaign level and not ad_set level.
- [x] Change log entry
- [ ] Publish gem