### PR TITLE
Add the product_set_id and url_tags fields to the AdCreative object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.8 (2019-03-25)
+  - Added the following fields to `AdCreative`: `product_set_id` and `url_tags`. (#37, @cte)
+
 ## 0.6.7 (2019-03-07)
   - Added the following fields to `AdSet`: `attribution_spec`, `start_time` and `end_time`. (#36, @cte)
 

--- a/facebook_ads.gemspec
+++ b/facebook_ads.gemspec
@@ -6,7 +6,7 @@
 # gem push facebook_ads-0.6.7.gem
 Gem::Specification.new do |s|
   s.name        = 'facebook_ads'
-  s.version     = '0.6.7'
+  s.version     = '0.6.8'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
   s.authors     = ['Chris Estreich']

--- a/lib/facebook_ads/ad_creative.rb
+++ b/lib/facebook_ads/ad_creative.rb
@@ -4,7 +4,7 @@ module FacebookAds
   # Ad ad creative has many ad images and belongs to an ad account.
   # https://developers.facebook.com/docs/marketing-api/reference/ad-creative
   class AdCreative < Base
-    FIELDS               = %w[id name object_story_id object_story_spec object_type thumbnail_url status].freeze
+    FIELDS               = %w[id name object_story_id object_story_spec object_type thumbnail_url product_set_id url_tags status].freeze
     CALL_TO_ACTION_TYPES = %w[SHOP_NOW INSTALL_MOBILE_APP USE_MOBILE_APP SIGN_UP DOWNLOAD BUY_NOW NO_BUTTON].freeze
 
     class << self


### PR DESCRIPTION
Complete list of fields can be found here:
https://developers.facebook.com/docs/marketing-api/reference/ad-creative