### PR TITLE
Modified FIELDS to exclude now invalid fields

### DIFF
--- a/lib/facebook_ads/ad_insight.rb
+++ b/lib/facebook_ads/ad_insight.rb
@@ -6,7 +6,7 @@ module FacebookAds
   # https://developers.facebook.com/docs/marketing-api/insights/overview
   # https://developers.facebook.com/docs/marketing-api/insights/fields/v2.8
   class AdInsight < Base
-    FIELDS = %w[account_id campaign_id adset_id ad_id objective impressions unique_actions cost_per_unique_action_type clicks cpc cpm cpp ctr spend reach relevance_score].freeze
+    FIELDS = %w[account_id campaign_id adset_id ad_id objective impressions unique_actions cost_per_unique_action_type clicks cpc cpm cpp ctr spend reach].freeze
 
     class << self
       def find(_id)


### PR DESCRIPTION
Seems like facebook has changed the fields list [ https://developers.facebook.com/docs/marketing-api/reference/ads-insights/ ] and relevance_score is no more there. Hence, fb returns a 400 error when we request ad_insights for an ad level. Removing relevance_score from the list fixes the issue.