### PR TITLE
Gem not working for FB 3.2

### DIFF
--- a/lib/facebook_ads/ad_insight.rb
+++ b/lib/facebook_ads/ad_insight.rb
@@ -6,7 +6,7 @@ module FacebookAds
   # https://developers.facebook.com/docs/marketing-api/insights/overview
   # https://developers.facebook.com/docs/marketing-api/insights/fields/v2.8
   class AdInsight < Base
-    FIELDS = %w[account_id campaign_id adset_id ad_id objective impressions unique_actions cost_per_unique_action_type clicks cpc cpm cpp ctr spend reach relevance_score].freeze
+    FIELDS = %w[account_id campaign_id adset_id ad_id objective impressions unique_actions cost_per_unique_action_type clicks cpc cpm cpp ctr spend reach].freeze
 
     class << self
       def find(_id)


### PR DESCRIPTION
since Facebook recent uppdate to 3.2 on May 2, gem is not working for account.ad_insights methods. 
the problem is that relevant_score is not longer supported. deleting this field is working again.