### PR TITLE
Update default api version to v8

### DIFF
--- a/lib/facebook_ads.rb
+++ b/lib/facebook_ads.rb
@@ -61,7 +61,7 @@ module FacebookAds
   end
 
   def self.api_version
-    @api_version ||= '7.0'
+    @api_version ||= '8.0'
   end
 
   def self.access_token=(access_token)

--- a/lib/facebook_ads/ad_set.rb
+++ b/lib/facebook_ads/ad_set.rb
@@ -69,7 +69,8 @@ module FacebookAds
     BID_STRATEGIES = %w[
       LOWEST_COST_WITHOUT_CAP
       LOWEST_COST_WITH_BID_CAP
-      TARGET_COST
+      COST_CAP
+      LOWEST_COST_WITH_MIN_ROAS
     ].freeze
 
     # AdAccount


### PR DESCRIPTION
The Facebook Marketing API v7.0 will be deprecated next week, on March 3, 2021:
https://developers.facebook.com/docs/graph-api/changelog/#available-marketing-api-versions

### Accomplishments

- [x] Updates the default version to v8.0
- [x] Removes deprecated Bid Strategies `TARGET_COST`
- [x] Adds new Bid Strategies `COST_CAP` & `LOWEST_COST_WITH_MIN_ROAS`